### PR TITLE
Pip10 - Fix pip.req dependance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@
 
 from os import path
 
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import find_packages, setup
 
 import versioneer


### PR DESCRIPTION
Correct the dependance to the pip.req package in the setup script, due to the new version of pip.
In the continuation of my issue : [#63](https://github.com/AngellusMortis/django_microsoft_auth/issues/63)