### PR TITLE
Fixes max length o365 ID

### DIFF
--- a/microsoft_auth/models.py
+++ b/microsoft_auth/models.py
@@ -20,7 +20,7 @@ for field in User._meta.fields:
 
 
 class MicrosoftAccount(models.Model):
-    microsoft_id = models.CharField(_('microsoft account id'), max_length=32)
+    microsoft_id = models.CharField(_('microsoft account id'), max_length=36)
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE, null=True,


### PR DESCRIPTION
Increase the max length o365 ID to 36 characters