### PR TITLE
[ISSUE-187]  Use `self.request` instead of relying on `settings.SITE_ID`

### DIFF
--- a/microsoft_auth/views.py
+++ b/microsoft_auth/views.py
@@ -48,7 +48,7 @@ class AuthenticateCallbackView(View):
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        domain = Site.objects.get_current().domain
+        domain = Site.objects.get_current(self.request).domain
 
         scheme = get_scheme(self.request)
 


### PR DESCRIPTION
For django sites that have multiple URLs, users should be able to login
via all URLs.  To allow this, we have to remove the dependency on
`settings.SITE_ID` which only allows us to specify a single site for
logging in.  The way to allow this is to send in `self.request`, which
will find the appropriate `Site` from the host header in the request.