### PR TITLE
Replace OperationalError with ProgrammingError

### DIFF
--- a/microsoft_auth/apps.py
+++ b/microsoft_auth/apps.py
@@ -2,7 +2,7 @@ import importlib
 
 from django.apps import AppConfig, apps
 from django.core.checks import Critical, Warning, register
-from django.db.utils import OperationalError
+from django.db.utils import ProgrammingError
 from django.test import RequestFactory
 
 
@@ -38,7 +38,7 @@ def microsoft_auth_validator(app_configs, **kwargs):
         Site.objects.get_current(request)
     except Site.DoesNotExist:
         pass
-    except OperationalError:
+    except ProgrammingError:
         errors.append(
             Warning(
                 "`django.contrib.sites` migrations not ran",


### PR DESCRIPTION
When sites migrations have not been run and the django_sites table does not exist, Django throws a `ProgrammingError`, in accordance with [PEP-0249](https://www.python.org/dev/peps/pep-0249/#programmingerror). This error is not caught, and the crash prevents a migration when sites have not been migrated before django_microsoft_auth.

### Crash log
```
(.venv) project > python manage.py migrate
Traceback (most recent call last):
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UndefinedTable: relation "django_site" does not exist
LINE 1: ..."django_site"."domain", "django_site"."name" FROM "django_si...
                                                             ^


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "manage.py", line 21, in <module>
    main()
  File "manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/management/base.py", line 361, in execute
    self.check()
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/management/base.py", line 390, in check
    include_deployment_checks=include_deployment_checks,
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/management/commands/migrate.py", line 65, in _run_checks
    issues.extend(super()._run_checks(**kwargs))
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/management/base.py", line 377, in _run_checks
    return checks.run_checks(**kwargs)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/core/checks/registry.py", line 72, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/microsoft_auth/apps.py", line 38, in microsoft_auth_validator
    Site.objects.get_current(request)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/contrib/sites/models.py", line 58, in get_current
    return self._get_site_by_id(site_id)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/contrib/sites/models.py", line 30, in _get_site_by_id
    site = self.get(pk=site_id)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/models/query.py", line 402, in get
    num = len(clone)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/models/query.py", line 256, in __len__
    self._fetch_all()
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/models/query.py", line 1242, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/models/query.py", line 55, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1100, in execute_sql
    cursor.execute(sql, params)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/backends/utils.py", line 99, in execute
    return super().execute(sql, params)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/utils.py", line 89, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/c03/Work/project/customer/back-end/project/.venv/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.ProgrammingError: relation "django_site" does not exist
LINE 1: ..."django_site"."domain", "django_site"."name" FROM "django_si...
```

### Solution
Replace `OperationalError` with `ProgrammingError`.