### PR TITLE
Fix ValueError when Microsoft account name contains no space

### DIFF
--- a/microsoft_auth/backends.py
+++ b/microsoft_auth/backends.py
@@ -155,7 +155,9 @@ class MicrosoftAuthenticationBackend(ModelBackend):
             fullname = data.get("name")
             first_name, last_name = "", ""
             if fullname is not None:
-                first_name, last_name = data["name"].split(" ", 1)
+                name_parts = data["name"].split(" ", 1)
+                if len(name_parts) == 2:
+                    first_name, last_name = name_parts
 
             try:
                 # create new Django user from provided data


### PR DESCRIPTION
Names are not guaranteed to contain both first name and last name.

This happens when they don't:
```
Internal Server Error: /microsoft/auth-callback/
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/utils/decorators.py", line 45, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/views.py", line 47, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/views.py", line 145, in post
    context = self.get_context_data(**request.POST.dict())
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/views.py", line 68, in get_context_data
    self._authenticate(kwargs.get("code"))
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/views.py", line 129, in _authenticate
    user = authenticate(self.request, code=code)
  File "/usr/local/lib/python3.6/site-packages/django/contrib/auth/__init__.py", line 73, in authenticate
    user = backend.authenticate(request, **credentials)
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/backends.py", line 49, in authenticate
    user = self._authenticate_user()
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/backends.py", line 60, in _authenticate_user
    return self._authenticate_microsoft_user()
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/backends.py", line 74, in _authenticate_microsoft_user
    return self._get_user_from_microsoft(claims)
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/backends.py", line 132, in _get_user_from_microsoft
    user = self._verify_microsoft_user(microsoft_user, data)
  File "/usr/local/lib/python3.6/site-packages/microsoft_auth/backends.py", line 158, in _verify_microsoft_user
    first_name, last_name = data["name"].split(" ", 1)
ValueError: not enough values to unpack (expected 2, got 1)
```