### PR TITLE
Case Insensitive Email User Retrieval

### DIFF
--- a/microsoft_auth/backends.py
+++ b/microsoft_auth/backends.py
@@ -159,7 +159,7 @@ class MicrosoftAuthenticationBackend(ModelBackend):
 
             try:
                 # create new Django user from provided data
-                user = User.objects.get(email=data["email"])
+                user = User.objects.get(email__iexact=data["email"])
 
                 if user.first_name == "" and user.last_name == "":
                     user.first_name = first_name


### PR DESCRIPTION
This solve the Issue #301 by setting the email user retrieval request case insensitive.
Sorry, I was not able to run the tests and don't have the time right now to investigate so I didn't wrote one.
Feel free to reject this pull request if it's not acceptable.
Best,
Jerome