### PR TITLE
Update client.py

### DIFF
--- a/microsoft_auth/client.py
+++ b/microsoft_auth/client.py
@@ -119,6 +119,7 @@ class MicrosoftClient(OAuth2Session):
         token = self.token["id_token"].encode("utf8")
 
         kid = jwt.get_unverified_header(token)["kid"]
+        jwk = None
         public_key = None
         for key in self.jwks:
             if kid == key["kid"]:


### PR DESCRIPTION
If jwk is not initialized and the kid is not in the OpenID cached config the library crashes into an unrecoverable state.