### PR TITLE
Add redirect paths for authentication

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -113,9 +113,25 @@ Quickstart
     you want as you normally.
 
 Running behind a reverse-proxy
----------
+------------------------------
 
 Make sure to pass your protocol with X-Forwarded-Proto so your callback url will be constructed properly
+
+Redirect based authentication flow
+----------------------------------
+
+`django_microsoft_auth` provides views at `to-auth-redirect/` and
+`from-auth-redirect/`, which can be used for customer facing authentication
+without loading a JavaScript script to the page.
+
+Redirect based authentication flow is triggered when user navigates to
+`to-auth-redirect/`, which takes in an optional `next` query parameter,
+for example, `to-auth-redirect/?next=/next/path`.
+This parameter is passed to the Authentication provider in state variable.
+After successfull authentication, authentication provider redirects the user to
+`from-auth-redirect/`, which logs in the user, parses the state variable, and
+redirects the user to the `next` path provided earlier or to `/` if no next path
+was provided.
 
 Test Site
 ---------

--- a/microsoft_auth/client.py
+++ b/microsoft_auth/client.py
@@ -61,7 +61,12 @@ class MicrosoftClient(OAuth2Session):
             current_site = Site.objects.first()
 
         domain = current_site.domain
-        path = reverse("microsoft_auth:auth-callback")
+        callback = reverse("microsoft_auth:auth-callback")
+        redirect = reverse("microsoft_auth:from-auth-redirect")
+        if not request or 'redirect' not in request.path:
+            path = callback
+        else:
+            path = redirect
         scope = " ".join(self.SCOPE_MICROSOFT)
 
         if self.config.MICROSOFT_AUTH_LOGIN_TYPE == LOGIN_TYPE_XBL:

--- a/microsoft_auth/urls.py
+++ b/microsoft_auth/urls.py
@@ -14,5 +14,15 @@ if config.MICROSOFT_AUTH_LOGIN_ENABLED:  # pragma: no branch
             "auth-callback/",
             views.AuthenticateCallbackView.as_view(),
             name="auth-callback",
+        ),
+        path(
+            "from-auth-redirect/",
+            views.AuthenticateCallbackRedirect.as_view(),
+            name="from-auth-redirect",
+        ),
+        path(
+            "to-auth-redirect/",
+            views.to_ms_redirect,
+            name="to-auth-redirect",
         )
     ]


### PR DESCRIPTION
Add `to-auth-redirect` and `from-auth-redirect` paths to url configuration to allow authentication without opening new window.

Fixes #283 