### PR TITLE
fixes the "removed in django4 warnings"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,26 +7,24 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev"
+  - "3.8"
   - "pypy3.5-6.0"
 env:
   global:
     - CC_TEST_REPORTER_ID=88fae959f68f3139aeeb3cd64ce11841115a336fdfc91b7cecd52958acb4d3e9
   matrix:
-    - DJANGO_VERSION=111
     - DJANGO_VERSION=21
     - DJANGO_VERSION=22
+    - DJANGO_VERSION=30
+    - DJANGO_VERSION=31
 matrix:
   fast_finish: true
-  allow_failures:
-    - python: "3.8-dev"
-      env: DJANGO_VERSION=22
   exclude:
-    # Only Django 3.x will support Python 3.8, so only test latest version
-    # until 3.0 comes out
-    - python: "3.8-dev"
-      env: DJANGO_VERSION=111
-    - python: "3.8-dev"
+    - python: "3.5"
+      env: DJANGO_VERSION=30
+    - python: "3.5"
+      env: DJANGO_VERSION=31
+    - python: "3.8"
       env: DJANGO_VERSION=21
   include:
     - python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "pypy3.5-6.0"
+  - "pypy3"
 env:
   global:
     - CC_TEST_REPORTER_ID=88fae959f68f3139aeeb3cd64ce11841115a336fdfc91b7cecd52958acb4d3e9

--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,10 @@ support, everything should largely already work, but you may need to patch
 
 Supported python versions:  3.5+
 
-Supported Django version: 1.11 LTS, 2.1+
+Supported Django version: 2.1+
 
 https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
 
-Note: Even though Django 1.11 LTS supports Python 3.4, I do not and you should
-not either. Official support for 3.4 was dropped in March 2019.
 
 Credits
 -------

--- a/microsoft_auth/conf.py
+++ b/microsoft_auth/conf.py
@@ -2,7 +2,7 @@ from importlib import import_module
 
 from django.test.signals import setting_changed
 from django.utils.functional import SimpleLazyObject
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 constance_config = None
 settings = None
@@ -134,6 +134,7 @@ DEFAULT_CONFIG = {
                 If the login type is Xbox Live, the parameters will be
                 `(User:user, dict: token)` where token is the Xbox Token,
                 see `microsoft_auth.client.MicrosoftClient.fetch_xbox_token`
+
                 for format"""
             ),
             str,
@@ -197,11 +198,13 @@ DEFAULT_CONFIG = {
 class SimpleConfig:
     def __init__(self, config=None):
         self._defaults = {}
+
         if config:
             self.add_default_config(config)
 
     def add_default_config(self, config):
         tmp_dict = {}
+
         for key, value in config["defaults"].items():
             tmp_dict[key] = value[0]
 
@@ -218,6 +221,7 @@ class SimpleConfig:
             pass
 
         # Check Constance first if it is installed
+
         if val is None and constance_config:
             try:
                 val = getattr(constance_config, attr)
@@ -242,12 +246,14 @@ def init_config():
     settings = django_settings
 
     # set constance config global
+
     if "constance" in settings.INSTALLED_APPS:
         from constance import config as constance_config
     else:
         constance_config = None
 
     # retrieve and set config class
+
     if (
         hasattr(settings, "MICROSOFT_AUTH_CONFIG_CLASS")
         and settings.MICROSOFT_AUTH_CONFIG_CLASS is not None
@@ -255,6 +261,7 @@ def init_config():
         module, _, obj = settings.MICROSOFT_AUTH_CONFIG_CLASS.rpartition(".")
         conf = import_module(module)
         config = getattr(conf, obj)
+
         if hasattr(config, "add_default_config"):
             config.add_default_config(DEFAULT_CONFIG)
     else:
@@ -279,6 +286,7 @@ def reload_settings(*args, **kwargs):
     setting = kwargs.get("setting", kwargs.get("key"))
 
     # only reinitialize config if settings changed
+
     if setting.startswith("MICROSOFT_AUTH_"):
         init_config()
 

--- a/microsoft_auth/context_processors.py
+++ b/microsoft_auth/context_processors.py
@@ -4,7 +4,7 @@ from django.contrib.sites.models import Site
 from django.core.signing import TimestampSigner
 from django.middleware.csrf import get_token
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .client import MicrosoftClient
 from .conf import LOGIN_TYPE_XBL, config

--- a/microsoft_auth/models.py
+++ b/microsoft_auth/models.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class UnicodeSpaceUsernameValidator(UnicodeUsernameValidator):
@@ -13,6 +13,7 @@ class UnicodeSpaceUsernameValidator(UnicodeUsernameValidator):
 
 # replace UnicodeUsernameValidator on User model...
 User = get_user_model()
+
 for field in User._meta.fields:
     if field.name == "username":
         for index, validator in enumerate(field.validators):

--- a/microsoft_auth/urls.py
+++ b/microsoft_auth/urls.py
@@ -5,13 +5,16 @@ app_name = "microsoft_auth"
 urlpatterns = []
 
 if config.MICROSOFT_AUTH_LOGIN_ENABLED:  # pragma: no branch
-    from django.urls import path
+    try:
+        from django.urls import re_path
+    except ImportError:
+        from django.conf.urls import url as re_path
 
     from . import views
 
     urlpatterns = [
-        path(
-            "auth-callback/",
+        re_path(
+            r"^auth-callback/$",
             views.AuthenticateCallbackView.as_view(),
             name="auth-callback",
         )

--- a/microsoft_auth/urls.py
+++ b/microsoft_auth/urls.py
@@ -5,13 +5,13 @@ app_name = "microsoft_auth"
 urlpatterns = []
 
 if config.MICROSOFT_AUTH_LOGIN_ENABLED:  # pragma: no branch
-    from django.conf.urls import re_path
+    from django.urls import path
 
     from . import views
 
     urlpatterns = [
-        re_path(
-            r"^auth-callback/$",
+        path(
+            "auth-callback/",
             views.AuthenticateCallbackView.as_view(),
             name="auth-callback",
         )

--- a/microsoft_auth/urls.py
+++ b/microsoft_auth/urls.py
@@ -5,11 +5,12 @@ app_name = "microsoft_auth"
 urlpatterns = []
 
 if config.MICROSOFT_AUTH_LOGIN_ENABLED:  # pragma: no branch
-    from django.conf.urls import url
+    from django.conf.urls import re_path
+
     from . import views
 
     urlpatterns = [
-        url(
+        re_path(
             r"^auth-callback/$",
             views.AuthenticateCallbackView.as_view(),
             name="auth-callback",

--- a/microsoft_auth/urls.py
+++ b/microsoft_auth/urls.py
@@ -1,3 +1,5 @@
+from django.urls import path
+
 from .conf import config
 
 app_name = "microsoft_auth"
@@ -5,16 +7,11 @@ app_name = "microsoft_auth"
 urlpatterns = []
 
 if config.MICROSOFT_AUTH_LOGIN_ENABLED:  # pragma: no branch
-    try:
-        from django.urls import re_path
-    except ImportError:
-        from django.conf.urls import url as re_path
-
     from . import views
 
     urlpatterns = [
-        re_path(
-            r"^auth-callback/$",
+        path(
+            "auth-callback/",
             views.AuthenticateCallbackView.as_view(),
             name="auth-callback",
         )

--- a/microsoft_auth/views.py
+++ b/microsoft_auth/views.py
@@ -9,7 +9,7 @@ from django.middleware.csrf import CSRF_TOKEN_LENGTH
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 

--- a/tests/site/urls.py
+++ b/tests/site/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, re_path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r"^accounts/", include("django.contrib.auth.urls")),
-    url(r"^admin/", admin.site.urls),
-    url(
+    re_path(r"^accounts/", include("django.contrib.auth.urls")),
+    re_path(r"^admin/", admin.site.urls),
+    re_path(
         r"^microsoft/",
         include("microsoft_auth.urls", namespace="microsoft_auth"),
     ),

--- a/tests/site/urls.py
+++ b/tests/site/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import include, re_path
 from django.contrib import admin
+from django.urls import include, path
 
 urlpatterns = [
-    re_path(r"^accounts/", include("django.contrib.auth.urls")),
-    re_path(r"^admin/", admin.site.urls),
-    re_path(
-        r"^microsoft/",
+    path("accounts/", include("django.contrib.auth.urls")),
+    path("admin/", admin.site.urls),
+    path(
+        "microsoft/",
         include("microsoft_auth.urls", namespace="microsoft_auth"),
     ),
 ]

--- a/tests/site/urls.py
+++ b/tests/site/urls.py
@@ -1,16 +1,11 @@
 from django.contrib import admin
-
-try:
-    from django.urls import include, re_path
-except ImportError:
-    from django.conf.urls import include
-    from django.conf.urls import url as re_path
+from django.urls import include, path
 
 urlpatterns = [
-    re_path(r"^accounts/", include("django.contrib.auth.urls")),
-    re_path(r"^admin/", admin.site.urls),
-    re_path(
-        r"^microsoft/",
+    path("accounts/", include("django.contrib.auth.urls")),
+    path("admin/", admin.site.urls),
+    path(
+        "microsoft/",
         include("microsoft_auth.urls", namespace="microsoft_auth"),
     ),
 ]

--- a/tests/site/urls.py
+++ b/tests/site/urls.py
@@ -1,11 +1,16 @@
 from django.contrib import admin
-from django.urls import include, path
+
+try:
+    from django.urls import include, re_path
+except ImportError:
+    from django.conf.urls import include
+    from django.conf.urls import url as re_path
 
 urlpatterns = [
-    path("accounts/", include("django.contrib.auth.urls")),
-    path("admin/", admin.site.urls),
-    path(
-        "microsoft/",
+    re_path(r"^accounts/", include("django.contrib.auth.urls")),
+    re_path(r"^admin/", admin.site.urls),
+    re_path(
+        r"^microsoft/",
         include("microsoft_auth.urls", namespace="microsoft_auth"),
     ),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-    py35-{dj111,dj21,dj22},
-    py36-{dj111,dj21,dj22},
-    py37-{dj111,dj21}
+    py35-{dj21,dj22},
+    py36-{dj21,dj22,dj30,dj31},
+    py37-{dj21,dj30,dj31}
     py37-{dj22,dj22-extras} # main line, only test extras here
-    py38-{dj22},
-    pypy3-{dj111,dj21,dj22},
+    py38-{dj22,dj30,dj31},
+    pypy3-{dj21,dj22,dj30,dj31},
     lint
 
 [testenv:lint]
@@ -21,9 +21,10 @@ commands=
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    dj111: Django>=1.11,<2.0
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
+    dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
     dj22-extras: djangoql
     dj22-extras: django-constance[database]
     -r{toxinidir}/tox-requirements.txt


### PR DESCRIPTION
This PR fixes two RemovedinDjango4 warning by replacing ugettext to gettext for translation and url to re_path