### PR TITLE
Fix algorithm typo

### DIFF
--- a/microsoft_auth/client.py
+++ b/microsoft_auth/client.py
@@ -151,7 +151,7 @@ class MicrosoftClient(OAuth2Session):
             claims = jwt.decode(
                 token,
                 public_key,
-                algorithms="RS256",
+                algorithms=["RS256"],
                 audience=self.config.MICROSOFT_AUTH_CLIENT_ID,
             )
         except jwt.PyJWTError as e:

--- a/microsoft_auth/client.py
+++ b/microsoft_auth/client.py
@@ -151,11 +151,11 @@ class MicrosoftClient(OAuth2Session):
             claims = jwt.decode(
                 token,
                 public_key,
-                algoithm="RS256",
+                algorithm="RS256",
                 audience=self.config.MICROSOFT_AUTH_CLIENT_ID,
             )
         except jwt.PyJWTError as e:
-            logger.warn("could verify id_token sig: {}".format(e))
+            logger.warn("could not verify id_token sig: {}".format(e))
             return None
 
         return claims

--- a/microsoft_auth/client.py
+++ b/microsoft_auth/client.py
@@ -151,7 +151,7 @@ class MicrosoftClient(OAuth2Session):
             claims = jwt.decode(
                 token,
                 public_key,
-                algorithm="RS256",
+                algorithms="RS256",
                 audience=self.config.MICROSOFT_AUTH_CLIENT_ID,
             )
         except jwt.PyJWTError as e:


### PR DESCRIPTION
We have been seeing the following error crop up when using the package:

```
could verify id_token sig: It is required that you pass in a value for the "algorithms" argument when calling decode().
```

It appears that the call to jwt.decode has a typo, this fix correct the spelling of one of the arguments from `algoithm` to `algorithm`.