### PR TITLE
Implement authentication using JWT assertion instead of client secret

### DIFF
--- a/microsoft_auth/apps.py
+++ b/microsoft_auth/apps.py
@@ -1,210 +1,53 @@
-import importlib
-
-from django.apps import AppConfig, apps
-from django.core.checks import Critical, Warning, register
-from django.db.utils import OperationalError, ProgrammingError
-from django.test import RequestFactory
+import base64
+import logging
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
+from django.apps import AppConfig, apps
 
-import base64
-import logging
+logger = logging.getLogger("django")
+
 
 class MicrosoftAuthConfig(AppConfig):
     name = "microsoft_auth"
     verbose_name = "Microsoft Auth"
 
     def ready(self):
+        from . import checks
         from .conf import config
 
-        if config.MICROSOFT_AUTH_CLIENT_CERTIFICATE != "":
-            (cert, key) = config.MICROSOFT_AUTH_CLIENT_CERTIFICATE
-            
+        if config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE != "":
+            cert = config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE
+
             try:
-                with open(cert, 'r') as file:
-                    cert_pem = file.read()
-                    cert_x509 = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
-	               
-                    thumbprint = cert_x509.fingerprint(hashes.SHA1())
-                    thumbprint_b64 = base64.b64encode(thumbprint).decode()
-
-                    config.MICROSOFT_AUTH_CLIENT_CERTIFICATE_THUMBPRINT = thumbprint_b64
-
+                cert_pem = open(cert, 'r').read()
             except (IOError, FileNotFoundError) as x:
-               logger.error("Cannot open or read client certificate: {}".format(cert))
+                logger.error("Cannot open or read client certificate: {}".
+                             format(cert))
+
+            cert_x509 = x509.load_pem_x509_certificate(
+                            cert_pem.encode(),
+                            default_backend())
+
+            thumbprint = cert_x509.fingerprint(hashes.SHA1())
+            thumbprint_b64 = base64.b64encode(thumbprint).decode()
+
+            config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE_THUMBPRINT = \
+                thumbprint_b64
+
+        if config.MICROSOFT_AUTH_ASSERTION_KEY != "":
+            key = config.MICROSOFT_AUTH_ASSERTION_KEY
 
             try:
-                with open(key, 'r') as file:
-                    key_pem = file.read()
-                    
-                    key = serialization.load_pem_private_key(
-                        key_pem.encode(), password=None, backend=default_backend()
-                    )
-
-                    config.MICROSOFT_AUTH_CLIENT_CERTIFICATE_KEY = key
-
+                key_pem = open(key, 'r').read()
             except (IOError, FileNotFoundError) as x:
-               logger.error("Cannot open or read client key: {}".format(key))
+                logger.error("Cannot open or read client key: {}".
+                             format(key))
 
+            key = serialization.load_pem_private_key(
+                            key_pem.encode(),
+                            password=None,
+                            backend=default_backend())
 
-@register()
-def microsoft_auth_validator(app_configs, **kwargs):
-    from django.contrib.sites.models import Site
-    from .conf import config, HOOK_SETTINGS
-
-    errors = []
-
-    if apps.is_installed("microsoft_auth") and not apps.is_installed(
-        "django.contrib.sites"
-    ):
-
-        errors.append(
-            Critical(
-                "`django.contrib.sites` is not installed",
-                hint=(
-                    "`microsoft_auth` requires `django.contrib.sites` "
-                    "to be installed and configured"
-                ),
-                id="microsoft_auth.E001",
-            )
-        )
-
-    try:
-        if not hasattr(config, "SITE_ID"):
-            request = RequestFactory().get("/", HTTP_HOST="example.com")
-            current_site = Site.objects.get_current(request)
-        else:
-            current_site = Site.objects.get_current()
-    except Site.DoesNotExist:
-        pass
-    except (OperationalError, ProgrammingError):
-        errors.append(
-            Warning(
-                "`django.contrib.sites` migrations not ran",
-                id="microsoft_auth.W001",
-            )
-        )
-    else:
-        if current_site.domain == "example.com":
-            errors.append(
-                Warning(
-                    (
-                        "`example.com` is still a valid site, Microsoft "
-                        "auth might not work"
-                    ),
-                    hint=(
-                        "Microsoft/Xbox auth uses OAuth, which requires "
-                        "a real redirect URI to come back to"
-                    ),
-                    id="microsoft_auth.W002",
-                )
-            )
-
-    if config.MICROSOFT_AUTH_LOGIN_ENABLED:  # pragma: no branch
-        if config.MICROSOFT_AUTH_CLIENT_ID == "":
-            errors.append(
-                Warning(
-                    ("`MICROSOFT_AUTH_CLIENT_ID` is not configured"),
-                    hint=(
-                        "`MICROSOFT_AUTH_LOGIN_ENABLED` is `True`, but "
-                        "`MICROSOFT_AUTH_CLIENT_ID` is empty. Microsoft "
-                        "auth will be disabled"
-                    ),
-                    id="microsoft_auth.W003",
-                )
-            )
-        if config.MICROSOFT_AUTH_CLIENT_SECRET == "" and config.MICROSOFT_AUTH_CLIENT_CERTIFICATE == "":
-            errors.append(
-                Warning(
-                    ("`MICROSOFT_AUTH_CLIENT_SECRET` and `MICROSOFT_AUTH_CLIENT_CERTIFICATE` is not configured"),
-                    hint=(
-                        "`MICROSOFT_AUTH_LOGIN_ENABLED` is `True`, but "
-                        "`MICROSOFT_AUTH_CLIENT_SECRET`and `MICROSOFT_AUTH_CLIENT_CERTIFICATE` is empty. "
-                        "Either `MICROSOFT_AUTH_CLIENT_SECRET` or `MICROSOFT_AUTH_CLIENT_CERTIFICATE` must be configured. "
-                        "Microsoft auth will be disabled"
-                    ),
-                    id="microsoft_auth.W004",
-                )
-            )
-
-        if config.MICROSOFT_AUTH_CLIENT_CERTIFICATE != "":
-                (cert, key) = config.MICROSOFT_AUTH_CLIENT_CERTIFICATE
-                
-                try:
-                    with open(cert, 'r') as file:
-                        cert_pem = file.read()
-                except IOError as x:
-                    errors.append(
-                        Warning(
-                            ("Cannot read client certificate located at: {}".format(cert)),
-                            hint=(
-                                "`MICROSOFT_AUTH_CLIENT_CERTIFICATE` is set, but the client cert cannot be read."
-                                " This can either be because the the file does not exist or django does not have permission to read the file"
-                            ),
-                            id="microsoft_auth.W005",
-                        )
-                    )
-
-                try:
-                    with open(key, 'r') as file:
-                        key_pem = file.read()
-                except IOError as x:
-                        errors.append(
-                            Warning(
-                                ("Cannot read client key located at: {}".format(key)),
-                                hint=(
-                                    "`MICROSOFT_AUTH_CLIENT_CERTIFICATE` is set, but the client key cannot be read."
-                                    " This can either be because the the file does not exist or django does not have permission to read the file"
-                                ),
-                                id="microsoft_auth.W006",
-                            )
-                        )
-
-    for hook_setting_name in HOOK_SETTINGS:
-        hook_setting = getattr(config, hook_setting_name)
-        if hook_setting != "":
-            parts = hook_setting.rsplit(".", 1)
-
-            if len(parts) != 2:
-                errors.append(
-                    Critical(
-                        ("{} is not a valid python path".format(hook_setting)),
-                        id="microsoft_auth.E002",
-                    )
-                )
-                return errors
-
-            module_path, function_name = parts[0], parts[1]
-            try:
-                module = importlib.import_module(module_path)
-            except ImportError:
-                errors.append(
-                    Critical(
-                        ("{} is not a valid module".format(module_path)),
-                        id="microsoft_auth.E003",
-                    )
-                )
-                return errors
-
-            try:
-                function = getattr(module, function_name)
-            except AttributeError:
-                errors.append(
-                    Critical(
-                        ("{} does not exist".format(hook_setting)),
-                        id="microsoft_auth.E004",
-                    )
-                )
-                return errors
-
-            if not callable(function):
-                errors.append(
-                    Critical(
-                        ("{} is not a callable".format(hook_setting)),
-                        id="microsoft_auth.E005",
-                    )
-                )
-
-    return errors
+            config.MICROSOFT_AUTH_ASSERTION_KEY_CONTENT = key

--- a/microsoft_auth/checks.py
+++ b/microsoft_auth/checks.py
@@ -1,0 +1,178 @@
+import importlib
+import os
+
+from django.apps import apps
+from django.core.checks import Critical, Warning, register
+from django.db.utils import OperationalError, ProgrammingError
+from django.test import RequestFactory
+
+
+@register()
+def microsoft_auth_validator(app_configs, **kwargs):
+    from django.contrib.sites.models import Site
+
+    from .conf import HOOK_SETTINGS, config
+
+    errors = []
+
+    if apps.is_installed("microsoft_auth") and not apps.is_installed(
+        "django.contrib.sites"
+    ):
+
+        errors.append(
+            Critical(
+                "`django.contrib.sites` is not installed",
+                hint=(
+                    "`microsoft_auth` requires `django.contrib.sites` "
+                    "to be installed and configured"
+                ),
+                id="microsoft_auth.E001",
+            )
+        )
+
+    try:
+        if not hasattr(config, "SITE_ID"):
+            request = RequestFactory().get("/", HTTP_HOST="example.com")
+            current_site = Site.objects.get_current(request)
+        else:
+            current_site = Site.objects.get_current()
+    except Site.DoesNotExist:
+        pass
+    except (OperationalError, ProgrammingError):
+        errors.append(
+            Warning(
+                "`django.contrib.sites` migrations not ran",
+                id="microsoft_auth.W001",
+            )
+        )
+    else:
+        if current_site.domain == "example.com":
+            errors.append(
+                Warning(
+                    (
+                        "`example.com` is still a valid site, Microsoft "
+                        "auth might not work"
+                    ),
+                    hint=(
+                        "Microsoft/Xbox auth uses OAuth, which requires "
+                        "a real redirect URI to come back to"
+                    ),
+                    id="microsoft_auth.W002",
+                )
+            )
+
+    if config.MICROSOFT_AUTH_LOGIN_ENABLED:  # pragma: no branch
+        if config.MICROSOFT_AUTH_CLIENT_ID == "":
+            errors.append(
+                Warning(
+                    ("`MICROSOFT_AUTH_CLIENT_ID` is not configured"),
+                    hint=(
+                        "`MICROSOFT_AUTH_LOGIN_ENABLED` is `True`, but "
+                        "`MICROSOFT_AUTH_CLIENT_ID` is empty. Microsoft "
+                        "auth will be disabled"
+                    ),
+                    id="microsoft_auth.W003",
+                )
+            )
+        if config.MICROSOFT_AUTH_CLIENT_SECRET == "" and \
+           config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE == "":
+            errors.append(
+                Warning(
+                    ("`MICROSOFT_AUTH_CLIENT_SECRET` and "
+                     "`MICROSOFT_AUTH_ASSERTION_CERTIFICATE`"
+                     " is not configured"),
+                    hint=(
+                        "`MICROSOFT_AUTH_LOGIN_ENABLED` is `True`, but "
+                        "`MICROSOFT_AUTH_CLIENT_SECRET`and "
+                        "`MICROSOFT_AUTH_ASSERTION_CERTIFICATE` is empty. "
+                        "Either `MICROSOFT_AUTH_CLIENT_SECRET` or "
+                        "`MICROSOFT_AUTH_ASSERTION_CERTIFICATE`"
+                        " must be configured. "
+                        "Microsoft auth will be disabled"
+                    ),
+                    id="microsoft_auth.W004",
+                )
+            )
+
+        if config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE != "":
+            filename = config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE
+            exists_and_readable = os.access(filename, os.R_OK)
+
+            if not exists_and_readable:
+                errors.append(
+                    Warning(
+                        ("`MICROSOFT_AUTH_ASSERTION_CERTIFICATE`"
+                         " cannot be read"),
+                        hint=(
+                         "MICROSOFT_AUTH_ASSERTION_CERTIFICATE is configured"
+                         " but either it doesn't exist"
+                         " or django does not have permission to read it"
+                        ),
+                        id="microsoft_auth.W005",
+                    )
+                )
+
+        if config.MICROSOFT_AUTH_ASSERTION_KEY != "":
+            filename = config.MICROSOFT_AUTH_ASSERTION_KEY
+            exists_and_readable = os.access(filename, os.R_OK)
+
+            if not exists_and_readable:
+                errors.append(
+                    Warning(
+                        ("`MICROSOFT_AUTH_ASSERTION_KEY`"
+                         " cannot be read"),
+                        hint=(
+                         "MICROSOFT_AUTH_ASSERTION_KEY is configured"
+                         " but either it doesn't exist"
+                         " or django does not have permission to read it"
+                        ),
+                        id="microsoft_auth.W005",
+                    )
+                )
+
+    for hook_setting_name in HOOK_SETTINGS:
+        hook_setting = getattr(config, hook_setting_name)
+        if hook_setting != "":
+            parts = hook_setting.rsplit(".", 1)
+
+            if len(parts) != 2:
+                errors.append(
+                    Critical(
+                        ("{} is not a valid python path".format(hook_setting)),
+                        id="microsoft_auth.E002",
+                    )
+                )
+                return errors
+
+            module_path, function_name = parts[0], parts[1]
+            try:
+                module = importlib.import_module(module_path)
+            except ImportError:
+                errors.append(
+                    Critical(
+                        ("{} is not a valid module".format(module_path)),
+                        id="microsoft_auth.E003",
+                    )
+                )
+                return errors
+
+            try:
+                function = getattr(module, function_name)
+            except AttributeError:
+                errors.append(
+                    Critical(
+                        ("{} does not exist".format(hook_setting)),
+                        id="microsoft_auth.E004",
+                    )
+                )
+                return errors
+
+            if not callable(function):
+                errors.append(
+                    Critical(
+                        ("{} is not a callable".format(hook_setting)),
+                        id="microsoft_auth.E005",
+                    )
+                )
+
+    return errors

--- a/microsoft_auth/client.py
+++ b/microsoft_auth/client.py
@@ -1,6 +1,6 @@
+import datetime
 import json
 import logging
-import datetime
 
 import jwt
 import requests
@@ -170,38 +170,45 @@ class MicrosoftClient(OAuth2Session):
 
         return super().authorization_url(auth_url, response_mode="form_post")
 
-
     def create_assertion(self):
-       payload = { 'sub': self.config.MICROSOFT_AUTH_CLIENT_ID,
+        """ Creates JWT assertion """
+
+        exp_at = datetime.datetime.utcnow() + datetime.timedelta(seconds=300)
+
+        payload = {'sub': self.config.MICROSOFT_AUTH_CLIENT_ID,
                    'iss': self.config.MICROSOFT_AUTH_CLIENT_ID,
                    'aud': self.openid_config["token_endpoint"],
-                   'exp': datetime.datetime.utcnow() + datetime.timedelta(seconds=300),
-                 }
+                   'exp': exp_at,
+                   }
 
-       thumbprint = self.config.MICROSOFT_AUTH_CLIENT_CERTIFICATE_THUMBPRINT
-       key        = self.config.MICROSOFT_AUTH_CLIENT_CERTIFICATE_KEY
+        thumbprint = self.config.\
+            MICROSOFT_AUTH_ASSERTION_CERTIFICATE_THUMBPRINT
+        key = self.config.MICROSOFT_AUTH_ASSERTION_KEY_CONTENT
 
-       assertion = jwt.encode(payload, key, algorithm='RS256',  headers={'x5t': thumbprint})
-       return assertion
+        assertion = jwt.encode(payload,
+                               key,
+                               algorithm='RS256',
+                               headers={'x5t': thumbprint}
+                               )
+        return assertion
 
     def fetch_token(self, **kwargs):
         """ Fetchs OAuth2 Token with given kwargs"""
 
-
-        if self.config.MICROSOFT_AUTH_CLIENT_CERTIFICATE != "":
-
+        if self.config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE != "":
             assertion = self.create_assertion()
 
-            arg = {'cert': self.config.MICROSOFT_AUTH_CLIENT_CERTIFICATE,
+            type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+            arg = {'cert': self.config.MICROSOFT_AUTH_ASSERTION_CERTIFICATE,
                    'include_client_id': True,
                    'client_id': self.config.MICROSOFT_AUTH_CLIENT_ID,
-                   'client_assertion_type':"urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                   'client_assertion':assertion,
-                  }
+                   'client_assertion_type': type,
+                   'client_assertion': assertion,
+                   }
 
         elif self.config.MICROSOFT_AUTH_CLIENT_SECRET != "":
             arg = {'client_secret': self.config.MICROSOFT_AUTH_CLIENT_SECRET}
-        
 
         return super().fetch_token(  # pragma: no cover
             self.openid_config["token_endpoint"],

--- a/microsoft_auth/conf.py
+++ b/microsoft_auth/conf.py
@@ -76,19 +76,21 @@ DEFAULT_CONFIG = {
             ),
             str,
         ),
-        "MICROSOFT_AUTH_CLIENT_CERTIFICATE": (
+        "MICROSOFT_AUTH_ASSERTION_CERTIFICATE": (
             "",
             _(
-                """Microsoft OAuth Client Certificate, see
-                https://apps.dev.microsoft.com/ for more."""
+                """Microsoft OAuth Assertion Certificate, see
+                https://docs.microsoft.com/en-us/azure/architecture
+                /multitenant-identity/client-assertion for more."""
             ),
             str,
         ),
-        "MICROSOFT_AUTH_CLIENT_KEY": (
+        "MICROSOFT_AUTH_ASSERTION_KEY": (
             "",
             _(
-                """Microsoft OAuth Client Certificate, see
-                https://apps.dev.microsoft.com/ for more."""
+                """Microsoft OAuth Assertion Certificate, see
+                https://docs.microsoft.com/en-us/azure/architecture
+                /multitenant-identity/client-assertion for more."""
             ),
             str,
         ),

--- a/microsoft_auth/conf.py
+++ b/microsoft_auth/conf.py
@@ -76,6 +76,22 @@ DEFAULT_CONFIG = {
             ),
             str,
         ),
+        "MICROSOFT_AUTH_CLIENT_CERTIFICATE": (
+            "",
+            _(
+                """Microsoft OAuth Client Certificate, see
+                https://apps.dev.microsoft.com/ for more."""
+            ),
+            str,
+        ),
+        "MICROSOFT_AUTH_CLIENT_KEY": (
+            "",
+            _(
+                """Microsoft OAuth Client Certificate, see
+                https://apps.dev.microsoft.com/ for more."""
+            ),
+            str,
+        ),
         "MICROSOFT_AUTH_EXTRA_SCOPES": (
             "",
             _(


### PR DESCRIPTION
RFC:
https://datatracker.ietf.org/doc/html/rfc7523

Description of Client assertion:
https://docs.microsoft.com/en-us/azure/architecture/multitenant-identity/client-assertion

Assertion format:
https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials


Created checks.py to check config is valid before loading assertion certificate and assertion key.
https://docs.djangoproject.com/en/3.2/topics/checks/
