### PR TITLE
Extend CSRF token validity to nearly a day, and use simpler error message

### DIFF
--- a/microsoft_auth/views.py
+++ b/microsoft_auth/views.py
@@ -30,8 +30,9 @@ class AuthenticateCallbackView(View):
 
     messages = {
         "bad_state": _(
-            "An invalid state variable was provided. "
-            "Please refresh the page and try again later."
+            "Login failed. "
+            "You probably left this page open for too long. "
+            "Please refresh the page and try again."
         ),
         "missing_code": _(
             "No authentication code was provided from " "Microsoft. Please try again."
@@ -94,7 +95,7 @@ class AuthenticateCallbackView(View):
             state = ""
 
         try:
-            state = loads(state, salt="microsoft_auth", max_age=300)
+            state = loads(state, salt="microsoft_auth", max_age=60*60*21)
         except BadSignature:  # pragma: no branch
             logger.debug("state has been tempered with")
             state = {}


### PR DESCRIPTION
Fix for issue AngellusMortis#420 by improving wording and extending CSRF validity timeframe.

* WordPress' CSRF ("nonces") last 24 hours as a frame of reference. Previous to this, django_microsoft_auth's default validity was just 5 minutes.
* The new error message for this problem does occur is more direct to non-technical users. It says login didn't work, what they did wrong (left the browser open for way too long, probably), and how to fix (refresh and try again immediately). The old message was technically right, but I think it only made enough sense to developers who already knew what the problem was, not average users with no idea what "state" was. Also, it said to try again later, when retrying immediately was possible. I think this new error message will mean a lot fewer support requests for site admins.

I'm using these changes as-is on a live site.
