### PR TITLE
Instantiate custom auth config class

### DIFF
--- a/microsoft_auth/conf.py
+++ b/microsoft_auth/conf.py
@@ -276,8 +276,10 @@ def init_config():
     if auth_config_class is not None:
         module, _, obj = auth_config_class.rpartition(".")
         conf = import_module(module)
-        # Get class and instantiate it
-        config = getattr(conf, obj)()
+        config = getattr(conf, obj)
+        # If class is not already instantiated, do so
+        if callable(config):
+            config = config()
 
         if hasattr(config, "add_default_config"):
             config.add_default_config(DEFAULT_CONFIG)

--- a/microsoft_auth/conf.py
+++ b/microsoft_auth/conf.py
@@ -272,14 +272,12 @@ def init_config():
         constance_config = None
 
     # retrieve and set config class
-
-    if (
-        hasattr(settings, "MICROSOFT_AUTH_CONFIG_CLASS")
-        and settings.MICROSOFT_AUTH_CONFIG_CLASS is not None
-    ):
-        module, _, obj = settings.MICROSOFT_AUTH_CONFIG_CLASS.rpartition(".")
+    auth_config_class = getattr(settings, "MICROSOFT_AUTH_CONFIG_CLASS", None)
+    if auth_config_class is not None:
+        module, _, obj = auth_config_class.rpartition(".")
         conf = import_module(module)
-        config = getattr(conf, obj)
+        # Get class and instantiate it
+        config = getattr(conf, obj)()
 
         if hasattr(config, "add_default_config"):
             config.add_default_config(DEFAULT_CONFIG)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -66,7 +66,7 @@ class ConfTests(TransactionTestCase):
         self.assertTrue(isinstance(config, SimpleTestNoDefaultConfig))
 
     @override_settings(MICROSOFT_AUTH_CONFIG_CLASS="tests.test_conf.SimpleTestConfig")
-    def test_custom_config_class(self):
+    def test_custom_config_class_uninstantiated(self):
         """Tests MICROSOFT_AUTH_CONFIG_CLASS set to another class (uninstantiated)"""
         from microsoft_auth.conf import config
 
@@ -75,7 +75,7 @@ class ConfTests(TransactionTestCase):
     @override_settings(
         MICROSOFT_AUTH_CONFIG_CLASS="tests.test_conf.SimpleTestNoDefaultConfig"
     )
-    def test_custom_config_class_with_no_default(self):
+    def test_custom_config_class_with_no_default_uninstantiated(self):
         """Tests MICROSOFT_AUTH_CONFIG_CLASS set to another class (uninstantiated) with no
         add_default_config option"""
         from microsoft_auth.conf import config

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2,8 +2,9 @@
 
 """
 
-from django.test import override_settings
 from unittest.mock import patch
+
+from django.test import override_settings
 
 from microsoft_auth.conf import DEFAULT_CONFIG, SimpleConfig
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -64,3 +64,20 @@ class ConfTests(TransactionTestCase):
         from microsoft_auth.conf import config
 
         self.assertTrue(isinstance(config, SimpleTestNoDefaultConfig))
+
+    @override_settings(MICROSOFT_AUTH_CONFIG_CLASS="tests.test_conf.SimpleTestConfig")
+    def test_custom_config_class(self):
+        """Tests MICROSOFT_AUTH_CONFIG_CLASS set to another class (uninstantiated)"""
+        from microsoft_auth.conf import config
+
+        self.assertTrue(isinstance(config, SimpleTestConfig))
+
+    @override_settings(
+        MICROSOFT_AUTH_CONFIG_CLASS="tests.test_conf.SimpleTestNoDefaultConfig"
+    )
+    def test_custom_config_class_with_no_default(self):
+        """Tests MICROSOFT_AUTH_CONFIG_CLASS set to another class (uninstantiated) with no
+        add_default_config option"""
+        from microsoft_auth.conf import config
+
+        self.assertTrue(isinstance(config, SimpleTestNoDefaultConfig))

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -3,6 +3,7 @@
 """
 
 from django.test import override_settings
+from unittest.mock import patch
 
 from microsoft_auth.conf import DEFAULT_CONFIG, SimpleConfig
 
@@ -68,9 +69,13 @@ class ConfTests(TransactionTestCase):
     @override_settings(MICROSOFT_AUTH_CONFIG_CLASS="tests.test_conf.SimpleTestConfig")
     def test_custom_config_class_uninstantiated(self):
         """Tests MICROSOFT_AUTH_CONFIG_CLASS set to another class (uninstantiated)"""
-        from microsoft_auth.conf import config
+        from microsoft_auth.conf import config, init_config
 
         self.assertTrue(isinstance(config, SimpleTestConfig))
+
+        with patch("tests.test_conf.SimpleTestConfig") as mockClass:
+            init_config()
+            mockClass.assert_called_once()
 
     @override_settings(
         MICROSOFT_AUTH_CONFIG_CLASS="tests.test_conf.SimpleTestNoDefaultConfig"
@@ -78,6 +83,10 @@ class ConfTests(TransactionTestCase):
     def test_custom_config_class_with_no_default_uninstantiated(self):
         """Tests MICROSOFT_AUTH_CONFIG_CLASS set to another class (uninstantiated) with no
         add_default_config option"""
-        from microsoft_auth.conf import config
+        from microsoft_auth.conf import config, init_config
 
         self.assertTrue(isinstance(config, SimpleTestNoDefaultConfig))
+
+        with patch("tests.test_conf.SimpleTestNoDefaultConfig") as mockClass:
+            init_config()
+            mockClass.assert_called_once()


### PR DESCRIPTION
I was excited to see the option for custom config classes when browsing through the code (it should be documented more) as I'm working on a multi tenant django project in which settings are set via tenant, rather than all in settings.py.

But when experimenting with this I noticed that the custom config class is never instantiated, and therefor fails.

This should remedy that.