### PR TITLE
Add Support For `First.Last` Name Formatting

### DIFF
--- a/microsoft_auth/backends.py
+++ b/microsoft_auth/backends.py
@@ -149,14 +149,12 @@ class MicrosoftAuthenticationBackend(ModelBackend):
             fullname = data.get("name")
             first_name, last_name = "", ""
             if fullname is not None:
-                try:
-                    # LastName, FirstName format
+                if ", " in fullname:
                     last_name, first_name = fullname.split(", ")
-                except ValueError:
-                    try:
-                        first_name, last_name = fullname.split(" ", 1)
-                    except ValueError:
-                        first_name = fullname
+                elif " " in fullname:
+                    first_name, last_name = fullname.split(" ", 1)
+                else:
+                    first_name = fullname
 
             try:
                 # create new Django user from provided data

--- a/microsoft_auth/backends.py
+++ b/microsoft_auth/backends.py
@@ -153,6 +153,8 @@ class MicrosoftAuthenticationBackend(ModelBackend):
                     last_name, first_name = fullname.split(", ")
                 elif " " in fullname:
                     first_name, last_name = fullname.split(" ", 1)
+                elif "." in fullname:
+                    first_name, last_name = fullname.split(".", 1)
                 else:
                     first_name = fullname
 

--- a/tests/test_backends/test_microsoft.py
+++ b/tests/test_backends/test_microsoft.py
@@ -185,7 +185,6 @@ class MicrosoftBackendsTests(TestCase):
         self.assertEqual(FIRST, self.unlinked_account.user.first_name)
         self.assertEqual(LAST, self.unlinked_account.user.last_name)
 
-
     @patch("microsoft_auth.backends.MicrosoftClient")
     def test_authenticate_existing_user_no_user_with_first_last_name(self, mock_client):
         mock_auth = Mock()
@@ -208,7 +207,6 @@ class MicrosoftBackendsTests(TestCase):
         self.assertEqual(EMAIL, self.unlinked_account.user.email)
         self.assertEqual(FIRST, self.unlinked_account.user.first_name)
         self.assertEqual(LAST, self.unlinked_account.user.last_name)
-
 
     @patch("microsoft_auth.backends.MicrosoftClient")
     def test_authenticate_existing_user_unlinked_user(self, mock_client):

--- a/tests/test_backends/test_microsoft.py
+++ b/tests/test_backends/test_microsoft.py
@@ -185,6 +185,31 @@ class MicrosoftBackendsTests(TestCase):
         self.assertEqual(FIRST, self.unlinked_account.user.first_name)
         self.assertEqual(LAST, self.unlinked_account.user.last_name)
 
+
+    @patch("microsoft_auth.backends.MicrosoftClient")
+    def test_authenticate_existing_user_no_user_with_first_last_name(self, mock_client):
+        mock_auth = Mock()
+        mock_auth.fetch_token.return_value = TOKEN
+        mock_auth.valid_scopes.return_value = True
+        mock_auth.get_claims.return_value = {
+            "sub": self.unlinked_account.microsoft_id,
+            "email": EMAIL,
+            "name": "{}.{}".format(FIRST, LAST),
+            "preferred_username": EMAIL,
+        }
+
+        mock_client.return_value = mock_auth
+
+        user = authenticate(self.request, code=CODE)
+        self.unlinked_account.refresh_from_db()
+
+        self.assertIsNot(user, None)
+        self.assertEqual(user.id, self.unlinked_account.user.id)
+        self.assertEqual(EMAIL, self.unlinked_account.user.email)
+        self.assertEqual(FIRST, self.unlinked_account.user.first_name)
+        self.assertEqual(LAST, self.unlinked_account.user.last_name)
+
+
     @patch("microsoft_auth.backends.MicrosoftClient")
     def test_authenticate_existing_user_unlinked_user(self, mock_client):
         mock_auth = Mock()


### PR DESCRIPTION
Includes a regression test for the issue. Refactors the code in question for easier readability when a larger number of name formats needs to be supported.

Fixes https://github.com/AngellusMortis/django_microsoft_auth/issues/486.