### PR TITLE
Don't require the 'email' field in the claims data.

### DIFF
--- a/microsoft_auth/backends.py
+++ b/microsoft_auth/backends.py
@@ -158,9 +158,18 @@ class MicrosoftAuthenticationBackend(ModelBackend):
                 else:
                     first_name = fullname
 
+            email = data.get("email")
+            if not email:
+                # No email available, let's generate something ourselves
+                if "@" in data["preferred_username"]:
+                    email = data["preferred_username"]
+                else:
+                    localpart = data["preferred_username"][:64]
+                    email = f"{localpart}@generated-by.django-microsoft-auth.invalid"
+
             try:
                 # create new Django user from provided data
-                user = User.objects.get(email=data["email"])
+                user = User.objects.get(email=email)
 
                 if user.first_name == "" and user.last_name == "":
                     user.first_name = first_name
@@ -171,7 +180,7 @@ class MicrosoftAuthenticationBackend(ModelBackend):
                     username=data["preferred_username"][:150],
                     first_name=first_name,
                     last_name=last_name,
-                    email=data["email"],
+                    email=email,
                 )
                 user.save()
 


### PR DESCRIPTION
In some implementations, the `email` field isn't returned from the authentication server. In those cases, make something up that will probably be just as stable as the users' email address.

In our current setup, we actually only receive the `sub` (Microsoft ID), `name` and `preferred_username` fields as general usable data for identifying a user. In our Django app, we actually identify the accounts using the Microsoft ID, but we see the need for an e-mail address to create the user.